### PR TITLE
Removed lines overriding some shard counts on inventory input

### DIFF
--- a/src/components/modals/InventoryManagementModal.tsx
+++ b/src/components/modals/InventoryManagementModal.tsx
@@ -287,16 +287,8 @@ export const InventoryManagementModal: React.FC<InventoryManagementModalProps> =
       console.log(`Shard ${shardId} (${rarity}): fused count = ${fusedCount}, tier level = ${tierLevel}`);
       
       // Store the tier level for the form
+      console.log(`  -> Setting form level to ${tierLevel}`);
       shardLevels[formKey] = tierLevel;
-      
-      // Also set inventory quantity based on tier level
-      if (tierLevel > 0 && tierLevel <= 10) {
-        const requiredCount = ATTRIBUTE_TIER_TO_SHARD_COUNT[rarity]?.[tierLevel] ?? 0;
-        console.log(`  -> Setting form level to ${tierLevel}, inventory to ${requiredCount}`);
-        if (requiredCount > 0) {
-          newInventory.set(shardId, requiredCount);
-        }
-      }
     }
 
     // Update shard levels in the form


### PR DESCRIPTION
When importing shards from a profile, shards in the Shard Level section (e.g. Newt, Salamander, etc.) would have their inventory counts overridden. I removed the lines overriding them.

To test, import the shard inventory from a profile with lvl 10 in one of the shards under the Shard Level section and verify the count is correct.