### PR TITLE
Fix incorrect bazaar prices

### DIFF
--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -100,8 +100,10 @@ export class DataService {
     this.bazaarPriceCache[cacheKey] = {};
 
     for (const shard of shards) {
-      const price = bazaarData.products[`${shard.internal_id}`]?.quick_status;
-      this.bazaarPriceCache[cacheKey][shard.id] = useInstantBuyPrices ? price?.buyPrice : price?.sellPrice;
+      const buyPrice = bazaarData.products[`${shard.internal_id}`]?.buy_summary[0]?.pricePerUnit;
+      const sellPrice = bazaarData.products[`${shard.internal_id}`]?.sell_summary[0]?.pricePerUnit;
+
+      this.bazaarPriceCache[cacheKey][shard.id] = useInstantBuyPrices ? buyPrice : sellPrice;
     }
   
     return this.bazaarPriceCache[cacheKey];

--- a/src/types/hypixelApiTypes.ts
+++ b/src/types/hypixelApiTypes.ts
@@ -3,10 +3,20 @@ export interface BazaarData {
   products: {
     [key: string]: {
       productId: string;
-      quick_status: {
-        buyPrice: number;
-        sellPrice: number;
-      };
+      sell_summary: {
+        [key: number]: {
+          amount: number,
+          pricePerUnit: number,
+          orders: number,
+        }
+      },
+      buy_summary: {
+        [key: number]: {
+          amount: number,
+          pricePerUnit: number,
+          orders: number,
+        }
+      },
     };
   };
 }


### PR DESCRIPTION
## Summary
Fixes #36

The `sellPrice` (and `buyPrice`) returned by `quick_status` in the Hypixel Bazaar API did not match the actual in-game Bazaar prices.

## Cause
Per the API documentation, `quick_status.sellPrice` and `buyPrice` are the weighted average of the top 2% of orders by volume, not the current top order price. This causes them to diverge from what's actually is in-game.

## Fix
Updated `DataService` to read the current price directly from `sell_summary[0].pricePerUnit` and `buy_summary[0].pricePerUnit`, which represent the top current order for each transaction type. Updated `BazaarData` types accordingly, replacing the `quick_status` price fields with the `sell_summary` / `buy_summary` structures.

## Testing
Verified with `SHARD_CUBOA`: the previous `sellPrice` from `quick_status` (1542.11) did not match the in-game sell price (183,195), while `sell_summary[0].pricePerUnit` (183,194.9) matches it correctly.
<img width="728" height="674" alt="api-cuboa" src="https://github.com/user-attachments/assets/55436f72-5ab9-4e47-85a1-8d9859ff23b2" />
<img width="313" height="316" alt="bazaar-cuboa" src="https://github.com/user-attachments/assets/fea56c53-7eb0-43ca-8707-4aaef710a3bd" />
